### PR TITLE
Fix README header text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 <p align="center">
+  <b>Skeleton schema for the Lilia framework.</b><br/>
+  A minimal starting point to build your own roleplay experience.
+</p>
+
+<p align="center">
   <img src="https://github.com/LiliaFramework/Lilia/blob/main/logo.png?raw=true" alt="Lilia Logo" width="200" />
 </p>
 


### PR DESCRIPTION
## Summary
- adjust the centered introductory snippet so it refers to the Skeleton schema instead of official modules

## Testing
- `glualint .` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68679ccfd80c83278288142e0822026c